### PR TITLE
fix: Update TailwindCSS PostCSS configuration for v4 compatibility

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "@eslint/js": "9.35.0",
+    "@tailwindcss/postcss": "^4.1.13",
     "@testing-library/jest-dom": "6.8.0",
     "@testing-library/react": "16.3.0",
     "@testing-library/user-event": "14.6.1",

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,6 +1,6 @@
 export default {
   plugins: {
-    tailwindcss: {},
+    '@tailwindcss/postcss': {},
     autoprefixer: {},
   },
 }


### PR DESCRIPTION
- Add @tailwindcss/postcss package to devDependencies
- Update postcss.config.js to use @tailwindcss/postcss plugin
- Fixes container build failure due to TailwindCSS v4 PostCSS plugin changes

Fixes #60