### PR TITLE
fix: remove deprecated @types/dompurify and @types/marked packages

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -73,8 +73,6 @@
     "@testing-library/jest-dom": "6.8.0",
     "@testing-library/react": "16.3.0",
     "@testing-library/user-event": "14.6.1",
-    "@types/dompurify": "3.2.0",
-    "@types/marked": "6.0.0",
     "@types/node": "24.5.2",
     "@types/react": "19.1.13",
     "@types/react-dom": "19.1.9",


### PR DESCRIPTION
These packages are deprecated as dompurify and marked now provide their own TypeScript definitions. Removing them eliminates deprecation warnings while maintaining full type safety.

Fixes #144

## Summary

Describe the change and the problem it solves.

## Changes

- [ ] Feature / Enhancement
- [ ] Bug fix
- [ ] Docs
- [ ] Chore / Refactor

## Checklist

- [ ] Conventional commit title (e.g., `feat(frontend): ...`)
- [ ] Tests added/updated
- [ ] Docs updated (README or docs/*)
- [ ] No secrets committed
- [ ] CI green locally if applicable

## Screenshots

If UI changed, include before/after screenshots or GIF.

## Linked Issues

Closes #

